### PR TITLE
#75 분양 글 등록 시 예외 처리, #79 token 관련 예외 처리 완료

### DIFF
--- a/src/main/java/com/smile/petpat/common/response/ErrorCode.java
+++ b/src/main/java/com/smile/petpat/common/response/ErrorCode.java
@@ -11,7 +11,6 @@ public enum ErrorCode {
     ILLEGAL_USERNAME_DUPLICATION(HttpStatus.BAD_REQUEST,  "중복된 아이디입니다."),
     ILLEGAL_USER_NOT_EXIST(HttpStatus.BAD_REQUEST, "가입되지 않은 아이디입니다."),
     ILLEGAL_PASSWORD_NOT_VALID (HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
-    ILLEGAL_INVALID_TOKEN(HttpStatus.BAD_REQUEST, "유효한 토큰이 아닙니다."),
     INVALID_PASSWORD_PATTERN(HttpStatus.BAD_REQUEST,  "비밀번호는 8자 이상 12자 이하의 길이의 영문자, 숫자, 특수문자(!@#$%^&*)만 사용 가능합니다."),
 
     // IMAGE

--- a/src/main/java/com/smile/petpat/common/response/ErrorResponse.java
+++ b/src/main/java/com/smile/petpat/common/response/ErrorResponse.java
@@ -7,6 +7,7 @@ import org.springframework.validation.Errors;
 import org.springframework.validation.FieldError;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -23,17 +24,22 @@ public class ErrorResponse {
 
     public ErrorResponse() {}
 
+    public ErrorResponse(HttpStatus status, String message) {
+        this.httpStatus = status;
+        this.message = message;
+    }
+
     static public ErrorResponse create() {
         return new ErrorResponse();
     }
 
+    public ErrorResponse message(String message) {
+        this.message = message;
+        return this;
+    }
 
     public ErrorResponse httpStatus(HttpStatus httpStatus) {
         this.httpStatus = httpStatus;
-        return this;
-    }
-    public ErrorResponse message(String message) {
-        this.message = message;
         return this;
     }
     public ErrorResponse errors(Errors errors) {

--- a/src/main/java/com/smile/petpat/image/domain/ImageUtils.java
+++ b/src/main/java/com/smile/petpat/image/domain/ImageUtils.java
@@ -1,7 +1,10 @@
 package com.smile.petpat.image.domain;
 
+import com.smile.petpat.common.exception.CustomException;
+import com.smile.petpat.common.response.ErrorCode;
 import org.springframework.stereotype.Component;
 
+import java.util.Set;
 import java.util.UUID;
 
 @Component
@@ -12,22 +15,22 @@ public class ImageUtils {
         return UUID.randomUUID().toString().concat(getFileExtension(fileName));
     }
 
-    public String getFileExtension(String fileName) {
+    /* 파일 확장명 체크 로직 */
+    public String getFileExtension(String fileName) throws CustomException {
         try {
             int idx = fileName.lastIndexOf(".");
-            String fileExtension = fileName.substring(idx+1);
-            // 파일 확장자 체크로직
-            switch (fileExtension) {
-                case "gif" : break;
-                case "png" : break;
-                case "jpg" : break;
-                case "jpeg" : break;
-                default: throw new IllegalArgumentException("파일 타입을 확인해주세요");
+            if (idx == -1 || idx == fileName.length() - 1) {
+                throw new CustomException(ErrorCode.WRONG_TYPE_IMAGE);
             }
-            return fileName.substring(fileName.lastIndexOf("."));
-        } catch (StringIndexOutOfBoundsException e) {
-            throw new IllegalArgumentException("파일 타입을 확인해주세요");
-        }
+            String fileExtension = fileName.substring(idx + 1);
 
+            Set<String> validExtensions = Set.of("gif", "png", "jpg", "jpeg");
+            if (!validExtensions.contains(fileExtension)) {
+                throw new CustomException(ErrorCode.WRONG_TYPE_IMAGE);
+            }
+            return "." + fileExtension;
+        } catch (IndexOutOfBoundsException e) {
+            throw new CustomException(ErrorCode.WRONG_TYPE_IMAGE);
+        }
     }
 }

--- a/src/main/java/com/smile/petpat/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/smile/petpat/jwt/JwtAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package com.smile.petpat.jwt;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -13,18 +14,26 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 // header에 token이 있으면 토큰을 인증
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final TokenProvider tokenProvider;
-
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         // header에서 token을 받아온다
         String token = tokenProvider.resolveToken(request);
+        String method = request.getMethod();
+        log.info("requestMethod : {}", method);
+        String servletPath = request.getServletPath();
         if (token != null) {
-            Authentication authentication = tokenProvider.getAuthentication(token);
+            Authentication authentication = tokenProvider.getAuthentication(token, response);
             SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        // 토큰이 없는 경우에 회원만 가능한 API 요청 시 에러 처리, 추후 거래게시판
+        else if (servletPath.equals("/api/v1/rehoming") && method.equals("POST") || servletPath.startsWith("/api/v1/likes") ||
+                 servletPath.startsWith("/api/v1/bookmarks") || servletPath.startsWith("/api/v1/rehoming/status")) {
+            tokenProvider.tokenNullChk(response);
         }
         filterChain.doFilter(request, response);
     }

--- a/src/main/java/com/smile/petpat/post/rehoming/domain/RehomingCommand.java
+++ b/src/main/java/com/smile/petpat/post/rehoming/domain/RehomingCommand.java
@@ -1,5 +1,7 @@
 package com.smile.petpat.post.rehoming.domain;
 
+import com.smile.petpat.common.exception.CustomException;
+import com.smile.petpat.common.response.ErrorCode;
 import com.smile.petpat.post.category.domain.CategoryGroup;
 import com.smile.petpat.post.category.domain.PetCategory;
 import com.smile.petpat.post.category.domain.PostType;
@@ -27,9 +29,7 @@ public class RehomingCommand {
     @NotBlank(message = "제목은 필수값입니다.") private String title;
     @NotBlank(message = "설명은 필수값입니다.") private String description;
     @NotBlank(message = "이름은 필수값입니다.") private String petName;
-    // 생년월일
     private String petAge;
-    // @NotBlank(message = "나이는 필수값입니다.") private String petAge;
     @NotNull(message = "카테고리는 필수값입니다.") private Long category;
     @NotNull(message = "종은 필수값입니다.") private Long type;
     @NotNull(message = "성별은 필수값입니다.") private PetGender gender;
@@ -40,6 +40,12 @@ public class RehomingCommand {
     private String fullAdName;
 
     public RehomingCommand toCommand() {
+        if (rehomingImg.size() > 5) {
+            throw new CustomException(ErrorCode.EXCEEDED_MAX_IMAGE_COUNT);
+        }
+        else if (rehomingImg.get(0).isEmpty()) {
+            throw new CustomException(ErrorCode.BELOW_MIN_IMAGE_COUNT);
+        }
         return RehomingCommand.builder()
                 .rehomingImg(rehomingImg)
                 .title(title)


### PR DESCRIPTION
- 분양 글 등록 시 `@Vaild` 걸려있는 항목 누락 시 발생하는 에러 response 형태 수정하였습니다. 
- 비회원이 token이 필요한 API 기능 요청 시 JWT token이 없다는 메세지와 400에러를 return하도록 수정하였습니다.
- 만료된 token 으로 API 요청 시 만료된 토큰이라는 메세지와 401에러 return 하도록 수정하였습니다.